### PR TITLE
Fix meaningless waiting when process exiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,6 +425,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,6 +513,7 @@ name = "rats-tls"
 version = "0.1.0"
 dependencies = [
  "foreign-types",
+ "pin-project",
  "tokio",
  "tokio-util 0.7.3",
 ]

--- a/entg/src/main.rs
+++ b/entg/src/main.rs
@@ -4,7 +4,6 @@ use anyhow::{anyhow, Context, Result};
 use clap::{ArgGroup, Parser};
 use log::info;
 use rats_tls::RatsTls;
-// use rats_tls_sys::*;
 use tokio::{
     io::{AsyncRead, AsyncWrite, DuplexStream},
     net::{TcpListener, TcpStream},

--- a/rats-tls/Cargo.toml
+++ b/rats-tls/Cargo.toml
@@ -9,3 +9,4 @@ edition = "2021"
 foreign-types = "0.5.0"
 tokio = { version = "1.19.2", features = ["full"] }
 tokio-util = { version = "0.7.3", features = ["io-util"] }
+pin-project = "1.0.12"


### PR DESCRIPTION
This PR fixes a bug in `RatsTls::negotiate_async()` that caused the program to wait indefinitely on exit.